### PR TITLE
support for exporting static final fields

### DIFF
--- a/java2typescript-jackson/src/main/java/java2typescript/jackson/module/StaticFieldExporter.java
+++ b/java2typescript-jackson/src/main/java/java2typescript/jackson/module/StaticFieldExporter.java
@@ -1,0 +1,138 @@
+/*******************************************************************************
+ * Copyright 2014 Florian Benz
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ******************************************************************************/
+package java2typescript.jackson.module;
+
+import java.lang.reflect.Field;
+import java.util.List;
+
+import java2typescript.jackson.module.grammar.AnyType;
+import java2typescript.jackson.module.grammar.ArrayType;
+import java2typescript.jackson.module.grammar.BooleanType;
+import java2typescript.jackson.module.grammar.EnumType;
+import java2typescript.jackson.module.grammar.Module;
+import java2typescript.jackson.module.grammar.NumberType;
+import java2typescript.jackson.module.grammar.StaticClassType;
+import java2typescript.jackson.module.grammar.StringType;
+import java2typescript.jackson.module.grammar.base.AbstractType;
+import java2typescript.jackson.module.grammar.base.Value;
+import java2typescript.jackson.module.visitors.TSJsonFormatVisitorWrapper;
+
+import com.fasterxml.jackson.databind.type.SimpleType;
+
+public class StaticFieldExporter {
+	private static final String CLASS_NAME_EXTENSION = "Static";
+
+	public static void export(Module module, List<Class<?>> classesToConvert)
+			throws IllegalArgumentException, IllegalAccessException {
+		for (Class<?> clazz : classesToConvert) {
+			if (clazz.isEnum()) {
+				continue;
+			}
+			StaticClassType staticClass = new StaticClassType(clazz.getSimpleName()
+					+ CLASS_NAME_EXTENSION);
+
+			Field[] declaredFields = clazz.getDeclaredFields();
+			for (Field field : declaredFields) {
+				if (isPublicStaticFinal(field.getModifiers())) {
+					final Value value = constructValue(module, field.getType(), field.get(null));
+					if (value != null) {
+						staticClass.getStaticFields().put(field.getName(), value);
+					}
+				}
+			}
+			if (staticClass.getStaticFields().size() > 0) {
+				module.getNamedTypes().put(staticClass.getName(), staticClass);
+			}
+		}
+	}
+
+	private static boolean isPublicStaticFinal(final int modifiers) {
+		return java.lang.reflect.Modifier.isPublic(modifiers)
+				&& java.lang.reflect.Modifier.isStatic(modifiers)
+				&& java.lang.reflect.Modifier.isFinal(modifiers);
+	}
+
+	private static Value constructValue(Module module, Class<?> type, Object rawValue)
+			throws IllegalArgumentException, IllegalAccessException {
+		if (type == boolean.class) {
+			return new Value(BooleanType.getInstance(), rawValue);
+		} else if (type == int.class) {
+			return new Value(NumberType.getInstance(), rawValue);
+		} else if (type == double.class) {
+			return new Value(NumberType.getInstance(), rawValue);
+		} else if (type == String.class) {
+			return new Value(StringType.getInstance(), "'" + (String) rawValue + "'");
+		} else if (type.isEnum()) {
+			final EnumType enumType = TSJsonFormatVisitorWrapper.parseEnumOrGetFromCache(module,
+					SimpleType.construct(type));
+			return new Value(enumType, enumType.getName() + "." + rawValue);
+		} else if (type.isArray()) {
+			final Class<?> componentType = type.getComponentType();
+			final Object[] array;
+			if (componentType == boolean.class) {
+				boolean[] tmpArray = (boolean[]) rawValue;
+				array = new Boolean[tmpArray.length];
+				for (int i = 0; i < array.length; i++) {
+					array[i] = Boolean.valueOf(tmpArray[i]);
+				}
+			} else if (componentType == int.class) {
+				int[] tmpArray = (int[]) rawValue;
+				array = new Integer[tmpArray.length];
+				for (int i = 0; i < array.length; i++) {
+					array[i] = Integer.valueOf(tmpArray[i]);
+				}
+			} else if (componentType == double.class) {
+				double[] tmpArray = (double[]) rawValue;
+				array = new Double[tmpArray.length];
+				for (int i = 0; i < array.length; i++) {
+					array[i] = Double.valueOf(tmpArray[i]);
+				}
+			} else {
+				array = (Object[]) rawValue;
+			}
+			final StringBuilder arrayValues = new StringBuilder();
+			arrayValues.append("[ ");
+			for (int i = 0; i < array.length; i++) {
+				arrayValues.append(constructValue(module, componentType, array[i]).getValue());
+				if (i < array.length - 1) {
+					arrayValues.append(", ");
+				}
+			}
+			arrayValues.append(" ]");
+			return new Value(new ArrayType(typeScriptTypeFromJavaType(module, componentType)),
+					arrayValues.toString());
+		}
+		return null;
+	}
+
+	private static AbstractType typeScriptTypeFromJavaType(Module module, Class<?> type) {
+		if (type == boolean.class) {
+			return BooleanType.getInstance();
+		} else if (type == int.class) {
+			return NumberType.getInstance();
+		} else if (type == double.class) {
+			return NumberType.getInstance();
+		} else if (type == String.class) {
+			return StringType.getInstance();
+		} else if (type.isEnum()) {
+			return TSJsonFormatVisitorWrapper.parseEnumOrGetFromCache(module, SimpleType
+					.construct(type));
+		} else if (type.isArray()) {
+			return new ArrayType(AnyType.getInstance());
+		}
+		throw new UnsupportedOperationException();
+	}
+}

--- a/java2typescript-jackson/src/main/java/java2typescript/jackson/module/grammar/StaticClassType.java
+++ b/java2typescript-jackson/src/main/java/java2typescript/jackson/module/grammar/StaticClassType.java
@@ -1,0 +1,53 @@
+/*******************************************************************************
+ * Copyright 2013 Raphael Jolivet, 2014 Florian Benz
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ******************************************************************************/
+package java2typescript.jackson.module.grammar;
+
+import static java.lang.String.format;
+
+import java.io.IOException;
+import java.io.Writer;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Map.Entry;
+
+import java2typescript.jackson.module.grammar.base.AbstractNamedType;
+import java2typescript.jackson.module.grammar.base.Value;
+
+public class StaticClassType extends AbstractNamedType {
+
+	private Map<String, Value> fields = new HashMap<String, Value>();
+
+	public StaticClassType(String className) {
+		super(className);
+	}
+
+	@Override
+	public void writeDef(Writer writer) throws IOException {
+		writer.write(format("class %s {\n", name));
+		for (Entry<String, Value> entry : fields.entrySet()) {
+			writer.write(format("    static %s: ", entry.getKey()));
+			entry.getValue().getType().write(writer);
+			writer.write(" = ");
+			writer.write(entry.getValue().getValue().toString());
+			writer.write(";\n");
+		}
+		writer.write("}");
+	}
+
+	public Map<String, Value> getStaticFields() {
+		return fields;
+	}
+}

--- a/java2typescript-jackson/src/main/java/java2typescript/jackson/module/grammar/base/Value.java
+++ b/java2typescript-jackson/src/main/java/java2typescript/jackson/module/grammar/base/Value.java
@@ -1,0 +1,35 @@
+/*******************************************************************************
+ * Copyright 2014 Florian Benz
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ******************************************************************************/
+package java2typescript.jackson.module.grammar.base;
+
+public class Value {
+	private AbstractType type;
+
+	private Object value;
+
+	public Value(AbstractType type, Object value) {
+		this.type = type;
+		this.value = value;
+	}
+
+	public AbstractType getType() {
+		return type;
+	}
+
+	public Object getValue() {
+		return value;
+	}
+}

--- a/java2typescript-jackson/src/main/java/java2typescript/jackson/module/visitors/TSJsonFormatVisitorWrapper.java
+++ b/java2typescript-jackson/src/main/java/java2typescript/jackson/module/visitors/TSJsonFormatVisitorWrapper.java
@@ -35,7 +35,8 @@ import com.fasterxml.jackson.databind.jsonFormatVisitors.JsonNumberFormatVisitor
 import com.fasterxml.jackson.databind.jsonFormatVisitors.JsonObjectFormatVisitor;
 import com.fasterxml.jackson.databind.jsonFormatVisitors.JsonStringFormatVisitor;
 
-public class TSJsonFormatVisitorWrapper extends ABaseTSJsonFormatVisitor implements JsonFormatVisitorWrapper {
+public class TSJsonFormatVisitorWrapper extends ABaseTSJsonFormatVisitor implements
+		JsonFormatVisitorWrapper {
 
 	public TSJsonFormatVisitorWrapper(ABaseTSJsonFormatVisitor parentHolder) {
 		super(parentHolder);
@@ -67,7 +68,7 @@ public class TSJsonFormatVisitorWrapper extends ABaseTSJsonFormatVisitor impleme
 	}
 
 	/** Either Java simple name or @JsonTypeName annotation */
-	private String getName(JavaType type) {
+	public static String getName(JavaType type) {
 		JsonTypeName typeName = type.getRawClass().getAnnotation(JsonTypeName.class);
 		if (typeName != null) {
 			return typeName.value();
@@ -83,7 +84,8 @@ public class TSJsonFormatVisitorWrapper extends ABaseTSJsonFormatVisitor impleme
 		AbstractNamedType namedType = getModule().getNamedTypes().get(name);
 
 		if (namedType == null) {
-			TSJsonObjectFormatVisitor visitor = new TSJsonObjectFormatVisitor(this, name, javaType.getRawClass());
+			TSJsonObjectFormatVisitor visitor = new TSJsonObjectFormatVisitor(this, name, javaType
+					.getRawClass());
 			type = visitor.getType();
 			getModule().getNamedTypes().put(visitor.getType().getName(), visitor.getType());
 			return visitor;
@@ -93,15 +95,15 @@ public class TSJsonFormatVisitorWrapper extends ABaseTSJsonFormatVisitor impleme
 		}
 	}
 
-	private EnumType parseEnumOrGetFromCache(JavaType javaType) {
+	public static EnumType parseEnumOrGetFromCache(Module module, JavaType javaType) {
 		String name = getName(javaType);
-		AbstractType namedType = getModule().getNamedTypes().get(name);
+		AbstractType namedType = module.getNamedTypes().get(name);
 		if (namedType == null) {
 			EnumType enumType = new EnumType(name);
 			for (Object val : javaType.getRawClass().getEnumConstants()) {
 				enumType.getValues().add(val.toString());
 			}
-			getModule().getNamedTypes().put(name, enumType);
+			module.getNamedTypes().put(name, enumType);
 			return enumType;
 		} else {
 			return (EnumType) namedType;
@@ -121,7 +123,7 @@ public class TSJsonFormatVisitorWrapper extends ABaseTSJsonFormatVisitor impleme
 	@Override
 	public JsonStringFormatVisitor expectStringFormat(JavaType jType) throws JsonMappingException {
 		if (jType.getRawClass().isEnum()) {
-			type = parseEnumOrGetFromCache(jType);
+			type = parseEnumOrGetFromCache(getModule(), jType);
 			return null;
 		} else {
 			return setTypeAndReturn(new TSJsonStringFormatVisitor(this));

--- a/java2typescript-jackson/src/test/java/java2typescript/jackson/module/StaticFieldExporterTest.java
+++ b/java2typescript-jackson/src/test/java/java2typescript/jackson/module/StaticFieldExporterTest.java
@@ -1,0 +1,87 @@
+/*******************************************************************************
+ * Copyright 2014 Florian Benz
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ******************************************************************************/
+package java2typescript.jackson.module;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.io.IOException;
+import java.io.StringWriter;
+import java.io.Writer;
+import java.util.ArrayList;
+
+import java2typescript.jackson.module.grammar.Module;
+
+import org.junit.Test;
+
+import com.fasterxml.jackson.annotation.JsonTypeName;
+
+public class StaticFieldExporterTest {
+	@JsonTypeName("ChangedEnumName")
+	enum Enum {
+		VAL1, VAL2, VAL3
+	}
+
+	static class TestClass {
+		public static final boolean MY_CONSTANT_BOOLEAN = true;
+
+		public static final String MY_CONSTANT_STRING = "Test";
+
+		public static final int MY_CONSTANT_INT = 10;
+
+		public static final double MY_CONSTANT_DOUBLE = 42.12;
+
+		public static final Enum MY_CONSTANT_ENUM = Enum.VAL1;
+
+		public static final Enum[] MY_CONSTANT_ENUM_ARRAY = new Enum[] { Enum.VAL1 };
+
+		public static final Enum[] MY_CONSTANT_ENUM_ARRAY_2 = new Enum[] { Enum.VAL1, Enum.VAL2 };
+
+		public static final String[] MY_CONSTANT_ARRAY = new String[] { "Test" };
+
+		public static final int[] MY_CONSTANT_INT_ARRAY = new int[] { 10, 12 };
+
+		public static final double[] MY_CONSTANT_DOUBLE_ARRAY = new double[] { 42.12 };
+
+		public static final boolean[] MY_CONSTANT_BOOLEAN_ARRAY = new boolean[] { true, false, true };
+
+		public String doNotExportAsStatic;
+	}
+
+	@Test
+	public void testTypeScriptDefinition() throws IOException, IllegalArgumentException,
+			IllegalAccessException {
+		Writer out = new StringWriter();
+
+		ArrayList<Class<?>> classesToConvert = new ArrayList<Class<?>>();
+		classesToConvert.add(TestClass.class);
+
+		Module module = new Module("mod");
+		StaticFieldExporter.export(module, classesToConvert);
+
+		module.write(out);
+
+		out.close();
+		final String result = out.toString();
+		System.out.println(result);
+		assertTrue(result.contains("export class TestClassStatic"));
+		assertTrue(result.contains("export enum ChangedEnumName"));
+		assertTrue(result.contains("static MY_CONSTANT_STRING: string = 'Test';"));
+		assertTrue(result
+				.contains("static MY_CONSTANT_ENUM_ARRAY_2: ChangedEnumName[] = [ ChangedEnumName.VAL1, ChangedEnumName.VAL2 ];"));
+		assertFalse(result.contains("doNotExportAsStatic"));
+	}
+}


### PR DESCRIPTION
This change enabled the export of static final fields from Java code so that Java constants can be accessed in TypeScript code.