### PR TITLE
fix #20 (and tests): now also classes without fields (that used to be…

### DIFF
--- a/java2typescript-jackson/src/main/java/java2typescript/jackson/module/visitors/TSJsonFormatVisitorWrapper.java
+++ b/java2typescript-jackson/src/main/java/java2typescript/jackson/module/visitors/TSJsonFormatVisitorWrapper.java
@@ -149,7 +149,12 @@ public class TSJsonFormatVisitorWrapper extends ABaseTSJsonFormatVisitor impleme
 
 	@Override
 	public JsonAnyFormatVisitor expectAnyFormat(JavaType type) throws JsonMappingException {
-		return setTypeAndReturn(new TSJsonAnyFormatVisitor(this, conf));
+		if ("java.lang.Object".equals(type.getRawClass().getName())) {
+			return setTypeAndReturn(new TSJsonAnyFormatVisitor(this, conf));
+		}
+		// probably just a class without fields/properties
+		useNamedClassOrParse(type);
+		return null;
 	}
 
 	@Override

--- a/java2typescript-jackson/src/test/java/java2typescript/jackson/module/ClassWithoutFieldsTest.java
+++ b/java2typescript-jackson/src/test/java/java2typescript/jackson/module/ClassWithoutFieldsTest.java
@@ -1,0 +1,73 @@
+package java2typescript.jackson.module;
+
+import java.io.IOException;
+import java.io.StringWriter;
+import java.io.Writer;
+
+import org.junit.Test;
+
+import java2typescript.jackson.module.grammar.Module;
+import java2typescript.jackson.module.util.ExpectedOutputChecker;
+import java2typescript.jackson.module.util.TestUtil;
+import java2typescript.jackson.module.writer.ExternalModuleFormatWriter;
+
+public class ClassWithoutFieldsTest {
+
+	static class ClassWithoutFields {
+	}
+
+	@Test
+	public void classWithoutFields() throws IOException {
+		// Arrange
+		Module module = TestUtil.createTestModule(null, ClassWithoutFields.class);
+		Writer out = new StringWriter();
+
+		// Act
+		new ExternalModuleFormatWriter().write(module, out);
+		out.close();
+		System.out.println(out);
+
+		// Assert
+		ExpectedOutputChecker.checkOutputFromFile(out);
+	}
+
+	@Test
+	public void referencesClassWithoutFields() throws IOException {
+		// Arrange
+		@SuppressWarnings("unused")
+		class RererencesClassWithoutFields {
+			public ClassWithoutFields classWithoutFields;
+			public Object javaLangObject;
+		}
+		Module module = TestUtil.createTestModule(null, RererencesClassWithoutFields.class);
+		Writer out = new StringWriter();
+
+		// Act
+		new ExternalModuleFormatWriter().write(module, out);
+		out.close();
+		System.out.println(out);
+
+		// Assert
+		ExpectedOutputChecker.checkOutputFromFile(out);
+	}
+
+	@Test
+	public void classWithOnlyMethod() throws IOException {
+		// Arrange
+		class ClassWithOnlyMethod {
+			@SuppressWarnings("unused")
+			public void onlyMethod() {
+			}
+		}
+		Module module = TestUtil.createTestModule(null, ClassWithOnlyMethod.class);
+		Writer out = new StringWriter();
+
+		// Act
+		new ExternalModuleFormatWriter().write(module, out);
+		out.close();
+		System.out.println(out);
+
+		// Assert
+		ExpectedOutputChecker.checkOutputFromFile(out);
+	}
+}

--- a/java2typescript-jackson/src/test/resources/java2typescript/jackson/module/ClassWithoutFieldsTest.classWithOnlyMethod.d.ts
+++ b/java2typescript-jackson/src/test/resources/java2typescript/jackson/module/ClassWithoutFieldsTest.classWithOnlyMethod.d.ts
@@ -1,0 +1,5 @@
+export interface ClassWithOnlyMethod {
+    onlyMethod(): void;
+}
+
+

--- a/java2typescript-jackson/src/test/resources/java2typescript/jackson/module/ClassWithoutFieldsTest.classWithoutFields.d.ts
+++ b/java2typescript-jackson/src/test/resources/java2typescript/jackson/module/ClassWithoutFieldsTest.classWithoutFields.d.ts
@@ -1,0 +1,3 @@
+export interface ClassWithoutFields {
+}
+

--- a/java2typescript-jackson/src/test/resources/java2typescript/jackson/module/ClassWithoutFieldsTest.referencesClassWithoutFields.d.ts
+++ b/java2typescript-jackson/src/test/resources/java2typescript/jackson/module/ClassWithoutFieldsTest.referencesClassWithoutFields.d.ts
@@ -1,0 +1,9 @@
+export interface RererencesClassWithoutFields {
+    classWithoutFields: ClassWithoutFields;
+    javaLangObject: any;
+}
+
+export interface ClassWithoutFields {
+}
+
+


### PR DESCRIPTION
… treated as `any` types) are added to the generated output (except java.lang.Object)