### PR TITLE
Use enum name() instead of toString()

### DIFF
--- a/java2typescript-jackson/src/main/java/java2typescript/jackson/module/visitors/TSJsonFormatVisitorWrapper.java
+++ b/java2typescript-jackson/src/main/java/java2typescript/jackson/module/visitors/TSJsonFormatVisitorWrapper.java
@@ -98,7 +98,7 @@ public class TSJsonFormatVisitorWrapper extends ABaseTSJsonFormatVisitor impleme
 		if (namedType == null) {
 			EnumType enumType = new EnumType(name);
 			for (Object val : javaType.getRawClass().getEnumConstants()) {
-				enumType.getValues().add(val.toString());
+				enumType.getValues().add(((Enum<?>)val).name());
 			}
 			module.getNamedTypes().put(name, enumType);
 			return enumType;


### PR DESCRIPTION
`toString()` in enums might be overriden for more human friendly names, but jax-rs will use the `name()` in marshalling.
