### PR TITLE
fix #45 - added maven project groupId prefix "com.github.raphaeljoliv…

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ To install the library using Maven add [JitPack](https://jitpack.io/) repository
     <dependency>
         <groupId>com.github.raphaeljolivet.java2typescript</groupId>
         <artifactId>java2typescript-maven-plugin</artifactId>
-        <version>v0.3.0.rc2</version><!-- see notes bellow to get either snapshot or specific commit or tag or other version -->
+        <version>v0.3.0.rc3-SNAPSHOT</version><!-- see notes bellow to get either snapshot or specific commit or tag or other version -->
     </dependency>
 </dependencies>
 ...

--- a/java2typescript-jackson/pom.xml
+++ b/java2typescript-jackson/pom.xml
@@ -15,7 +15,11 @@
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
-
+	<parent>
+		<groupId>com.github.raphaeljolivet.java2typescript</groupId>
+		<artifactId>java2typescript</artifactId>
+		<version>v0.3.0.rc3-SNAPSHOT</version>
+	</parent>
 	<artifactId>java2typescript-jackson</artifactId>
 	<name>java2typescript jackson module</name>
 	<description>
@@ -59,10 +63,4 @@
 
 
 	</dependencies>
-
-	<parent>
-		<groupId>java2typescript</groupId>
-		<artifactId>java2typescript</artifactId>
-		<version>0.3-SNAPSHOT</version>
-	</parent>
 </project>

--- a/java2typescript-jaxrs/pom.xml
+++ b/java2typescript-jaxrs/pom.xml
@@ -8,16 +8,14 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
-		<groupId>java2typescript</groupId>
+		<groupId>com.github.raphaeljolivet.java2typescript</groupId>
 		<artifactId>java2typescript</artifactId>
-		<version>0.3-SNAPSHOT</version>
+		<version>v0.3.0.rc3-SNAPSHOT</version>
 	</parent>
 
-	<groupId>java2typescript</groupId>
 	<artifactId>java2typescript-jaxrs</artifactId>
 	<name>java2typescript jaxrs</name>
-	<version>0.3-SNAPSHOT</version>
-	
+
 	<description>A module to generate JSON descriptor and Typescript definition out of a REST Service, out of JAX-RS annotations</description>
 	<dependencies>
 		<dependency>
@@ -36,13 +34,12 @@
 			<version>15.0</version>
 		</dependency>
 		<dependency>
-			<groupId>java2typescript</groupId>
+			<groupId>${project.groupId}</groupId>
 			<artifactId>java2typescript-jackson</artifactId>
 			<version>${project.version}</version>
 		</dependency>
-		
 		<dependency>
-			<groupId>java2typescript</groupId>
+			<groupId>${project.groupId}</groupId>
 			<artifactId>sample-web-app-server</artifactId>
 			<version>${project.version}</version>
 			<scope>test</scope>

--- a/java2typescript-maven-plugin/pom.xml
+++ b/java2typescript-maven-plugin/pom.xml
@@ -2,23 +2,18 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <groupId>java2typescript</groupId>
+    <groupId>com.github.raphaeljolivet.java2typescript</groupId>
     <artifactId>java2typescript</artifactId>
-    <version>0.3-SNAPSHOT</version>
+    <version>v0.3.0.rc3-SNAPSHOT</version>
   </parent>
 
-  <!-- Maven plugins descriptor needs to contain the same group, artifact and version as used by the application pom.xml -->
-  <groupId>com.github.raphaeljolivet.java2typescript</groupId><!-- different compared to parent, as plugin will be distributed through jitpack.io with this group id -->
   <artifactId>java2typescript-maven-plugin</artifactId>
-  <version>v0.3.0.rc2</version><!-- different compared to parent, as plugin will be distributed through jitpack.io with this version -->
-
   <packaging>maven-plugin</packaging>
   <name>java2typescript maven plugin</name>
   <url>http://maven.apache.org</url>
 
   <properties>
     <maven.version>2.2.1</maven.version>
-    <java2typescript.version>0.3-SNAPSHOT</java2typescript.version>
   </properties>
 
   <build>
@@ -38,8 +33,8 @@
     </plugins>
     <pluginManagement>
       <plugins>
-        <!--This plugin's configuration is used to store Eclipse m2e settings only. It has no influence on the Maven build 
-          itself. -->
+        <!--This plugin's configuration is used to store Eclipse m2e settings only.
+        It has no influence on the Maven build itself. -->
         <plugin>
           <groupId>org.eclipse.m2e</groupId>
           <artifactId>lifecycle-mapping</artifactId>
@@ -115,9 +110,9 @@
       <version>1.3.8</version>
     </dependency>
     <dependency>
-      <groupId>java2typescript</groupId>
+      <groupId>${project.groupId}</groupId>
       <artifactId>java2typescript-jaxrs</artifactId>
-      <version>${java2typescript.version}</version>
+      <version>${project.version}</version>
     </dependency>
   </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -1,14 +1,13 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	
-	<groupId>java2typescript</groupId>
+	<groupId>com.github.raphaeljolivet.java2typescript</groupId>
 	<artifactId>java2typescript</artifactId>
-	<version>0.3-SNAPSHOT</version>
+	<version>v0.3.0.rc3-SNAPSHOT</version>
 	<packaging>pom</packaging>
 	<name>java2typescript</name>
 
 	<properties>
-		<java2typescript.version>0.3-SNAPSHOT</java2typescript.version>
 		<maven.compiler.source>1.6</maven.compiler.source>
 		<maven.compiler.target>1.6</maven.compiler.target>
     	<github.global.server>github</github.global.server>

--- a/sample-web-app-client/pom.xml
+++ b/sample-web-app-client/pom.xml
@@ -3,9 +3,9 @@
 	<modelVersion>4.0.0</modelVersion>
 
 	<parent>
-		<groupId>java2typescript</groupId>
+		<groupId>com.github.raphaeljolivet.java2typescript</groupId>
 		<artifactId>java2typescript</artifactId>
-		<version>0.3-SNAPSHOT</version>
+		<version>v0.3.0.rc3-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>sample-web-app-client</artifactId>
@@ -21,9 +21,9 @@
 	<build>
 		<plugins>
 			<plugin>
-				<groupId>java2typescript</groupId>
+				<groupId>com.github.raphaeljolivet.java2typescript</groupId>
 				<artifactId>java2typescript-maven-plugin</artifactId>
-				<version>0.3-SNAPSHOT</version>
+				<version>v0.3.0.rc3-SNAPSHOT</version>
 				<configuration>
 					<serviceClass>com.example.rs.PeopleRestService</serviceClass>
 					<moduleName>People</moduleName>

--- a/sample-web-app-server/pom.xml
+++ b/sample-web-app-server/pom.xml
@@ -2,12 +2,11 @@
 	<modelVersion>4.0.0</modelVersion>
 
     <parent>
-	    <groupId>java2typescript</groupId>
+        <groupId>com.github.raphaeljolivet.java2typescript</groupId>
 	    <artifactId>java2typescript</artifactId>
-	    <version>0.3-SNAPSHOT</version>
+        <version>v0.3.0.rc3-SNAPSHOT</version>
     </parent>
 	
-	 <groupId>java2typescript</groupId>
     <artifactId>sample-web-app-server</artifactId>
 	<packaging>jar</packaging>
 

--- a/sample-web-app/pom.xml
+++ b/sample-web-app/pom.xml
@@ -2,9 +2,9 @@
 	<modelVersion>4.0.0</modelVersion>
 
     <parent>
-	    <groupId>java2typescript</groupId>
+        <groupId>com.github.raphaeljolivet.java2typescript</groupId>
 	    <artifactId>java2typescript</artifactId>
-	    <version>0.3-SNAPSHOT</version>
+	    <version>v0.3.0.rc3-SNAPSHOT</version>
     </parent>
 	
     <artifactId>sample-web-app</artifactId>
@@ -99,7 +99,7 @@
             <plugin>
                 <groupId>com.github.raphaeljolivet.java2typescript</groupId>
                 <artifactId>java2typescript-maven-plugin</artifactId>
-                <version>v0.3.0.rc2</version>
+                <version>v0.3.0.rc3-SNAPSHOT</version>
                 <configuration>
                     <serviceClass>com.example.rs.PeopleRestService</serviceClass>
                     <moduleName>People</moduleName>


### PR DESCRIPTION
…et." to match maven plugin groupId when downloading it from jitpack.io repo (for maven plugins groupId, artifact and version are double-checked - content of maven plugin pom.xml must match groupId,artifact,version that was used to download the plugin)