### PR TITLE
NullPointerException fix

### DIFF
--- a/java2typescript-jackson/src/main/java/java2typescript/jackson/module/visitors/TSJsonFormatVisitorWrapper.java
+++ b/java2typescript-jackson/src/main/java/java2typescript/jackson/module/visitors/TSJsonFormatVisitorWrapper.java
@@ -15,27 +15,14 @@
  ******************************************************************************/
 package java2typescript.jackson.module.visitors;
 
+import com.fasterxml.jackson.databind.JavaType;
+import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.jsonFormatVisitors.*;
+import java2typescript.jackson.module.Configuration;
 import java2typescript.jackson.module.grammar.EnumType;
 import java2typescript.jackson.module.grammar.Module;
 import java2typescript.jackson.module.grammar.base.AbstractNamedType;
 import java2typescript.jackson.module.grammar.base.AbstractType;
-
-import com.fasterxml.jackson.annotation.JsonTypeName;
-import com.fasterxml.jackson.databind.JavaType;
-import com.fasterxml.jackson.databind.JsonMappingException;
-import com.fasterxml.jackson.databind.jsonFormatVisitors.JsonAnyFormatVisitor;
-import com.fasterxml.jackson.databind.jsonFormatVisitors.JsonArrayFormatVisitor;
-import com.fasterxml.jackson.databind.jsonFormatVisitors.JsonBooleanFormatVisitor;
-import com.fasterxml.jackson.databind.jsonFormatVisitors.JsonFormatVisitable;
-import com.fasterxml.jackson.databind.jsonFormatVisitors.JsonFormatVisitorWrapper;
-import com.fasterxml.jackson.databind.jsonFormatVisitors.JsonIntegerFormatVisitor;
-import com.fasterxml.jackson.databind.jsonFormatVisitors.JsonMapFormatVisitor;
-import com.fasterxml.jackson.databind.jsonFormatVisitors.JsonNullFormatVisitor;
-import com.fasterxml.jackson.databind.jsonFormatVisitors.JsonNumberFormatVisitor;
-import com.fasterxml.jackson.databind.jsonFormatVisitors.JsonObjectFormatVisitor;
-import com.fasterxml.jackson.databind.jsonFormatVisitors.JsonStringFormatVisitor;
-
-import java2typescript.jackson.module.Configuration;
 
 public class TSJsonFormatVisitorWrapper extends ABaseTSJsonFormatVisitor implements
 		JsonFormatVisitorWrapper {
@@ -119,7 +106,7 @@ public class TSJsonFormatVisitorWrapper extends ABaseTSJsonFormatVisitor impleme
 
 	@Override
 	public JsonStringFormatVisitor expectStringFormat(JavaType jType) throws JsonMappingException {
-		if (jType.getRawClass().isEnum()) {
+		if (jType != null && jType.getRawClass().isEnum()) {
 			type = parseEnumOrGetFromCache(getModule(), jType);
 			return null;
 		} else {


### PR DESCRIPTION
in com.fasterxml.jackson.databind.ext.CoreXMLSerializers the visitor is passed with a null as JavaType. Because of this a NPE could be thrown in TSJsonFormatVisotorWrapper.expectStringFormat(null)