### PR TITLE
Add enumToStringLiteralType option

### DIFF
--- a/java2typescript-jackson/README.md
+++ b/java2typescript-jackson/README.md
@@ -28,11 +28,49 @@ See the [tests for excluded methods](src/test/java/java2typescript/jackson/modul
 ### Enums
 Java enums are converted to TypeScript enums by default,
 but TypeSafe enum pattern can be used to force the generation of classes instead of enums (see [the description of the issue](https://github.com/raphaeljolivet/java2typescript/issues/13).
-See [this output](src/test/resources/java2typescript/jackson/module/WriterPreferencesTest.enumToEnumPattern.d.ts) from the [test that turns on this preference](src/test/java/java2typescript/jackson/module/WriterPreferencesTest.java#L44) using
+See [this output](src/test/resources/java2typescript/jackson/module/WriterPreferencesTest.enumToEnumPattern.d.ts) from the [test that turns on this preference](src/test/java/java2typescript/jackson/module/WriterPreferencesTest.java#L49) using
 
 ```Java
 mWriter.preferences.useEnumPattern();
 ```
+
+Another option available is to write enums as [String Literal Types](https://www.typescriptlang.org/docs/handbook/advanced-types.html#string-literal-types).
+The advantage here is that the generated typescript definitions can be used with JSON that has the string value of the corresponding java enum value, while still maintaining
+strong-typing. For example, take this java DTO class:
+
+```java
+class MyDto {
+    static enum MyEnum {
+        VAL1, VAl2, VAL3
+    }
+    public MyEnum myKey;
+}
+
+```
+
+A java web server which is converting an instance of `MyDto` to JSON will likely return something like this:
+
+```json
+{
+  "myKey": "VAL1"
+}
+```
+
+The default for this tool is to create Typescript enums, which are integer-based. This will not work without some
+conversion layer in your client code. To mitigate, you can use the `useStringLiteralTypeForEnums` option on the module
+writer. This will generate a Typescript definition like this:
+
+```TypeScript
+export interface MyDto {
+    myKey: MyEnum;
+}
+export type MyEnum = "VAL1" | "VAl2" | "VAL3";
+```
+
+This will keep strong-typing for the values, while allowing for string literal values of enum properties. Take a look at
+the [test that turns on this preference](src/test/java/java2typescript/jackson/module/WriterPreferencesTest.java#L67)
+
+
 
 ### Mapping specific java classes to custom TypeScript types
 There are scenarios when you might want to use a different TypeScript type instead of the default Java Type. There are several options for doing this depending how you want it to be done:

--- a/java2typescript-jackson/src/main/java/java2typescript/jackson/module/writer/EnumTypeToStringLiteralTypeWriter.java
+++ b/java2typescript-jackson/src/main/java/java2typescript/jackson/module/writer/EnumTypeToStringLiteralTypeWriter.java
@@ -1,0 +1,54 @@
+package java2typescript.jackson.module.writer;
+
+import java2typescript.jackson.module.grammar.EnumType;
+import java2typescript.jackson.module.grammar.base.AbstractNamedType;
+
+import java.io.IOException;
+import java.io.Writer;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+
+import static java.lang.String.format;
+
+/**
+ * Another alternate way of converting Java enums. This writer will convert enums to what is known as a String Literal
+ * Type in TypeScript (>=1.8). The advantage here is that the generated typescript definitions can be used with JSON
+ * that has the string value of the corresponding java enum value, while still maintaining strong-typing.
+ * More info: https://www.typescriptlang.org/docs/handbook/advanced-types.html#string-literal-types
+ * @author Andy Perlitch
+ */
+public class EnumTypeToStringLiteralTypeWriter implements CustomAbstractTypeWriter {
+
+	@Override
+	public boolean accepts(AbstractNamedType type, WriterPreferences preferences) {
+		return type instanceof EnumType;
+	}
+
+	@Override
+	public void writeDef(AbstractNamedType type, Writer writer, WriterPreferences preferences) throws IOException {
+		// metadata about the enum being converted
+		EnumType enumType = (EnumType) type;
+		String enumTypeName = enumType.getName();
+		List<String> enumConstants = enumType.getValues();
+
+		writer.write(format("type %s =\n", enumTypeName));
+		preferences.increaseIndentation();
+		if(preferences.isSort()) {
+			enumConstants = SortUtil.sort(enumConstants);
+		}
+		Iterator<String> iter = enumConstants.iterator();
+		boolean isFirst = true;
+		while(iter.hasNext()) {
+			String value = iter.next();
+			writer.write(format("%s%s\"%s\"%s",
+					preferences.getIndentation(),
+					isFirst ? "" : "| ",
+					value,
+					iter.hasNext() ? "\n" : ";"
+			));
+			isFirst = false;
+		}
+		preferences.decreaseIndention();
+	}
+}

--- a/java2typescript-jackson/src/main/java/java2typescript/jackson/module/writer/WriterPreferences.java
+++ b/java2typescript-jackson/src/main/java/java2typescript/jackson/module/writer/WriterPreferences.java
@@ -13,6 +13,17 @@ public class WriterPreferences {
 
 	private List<CustomAbstractTypeWriter> customWriters = new ArrayList<CustomAbstractTypeWriter>();
 	private boolean useEnumPattern;
+
+	public boolean isStringLiteralTypeForEnums() {
+		return enumAsStringLiteralType;
+	}
+
+	public void useStringLiteralTypeForEnums() {
+        addWriter(new EnumTypeToStringLiteralTypeWriter());
+		this.enumAsStringLiteralType = true;
+	}
+
+	private boolean enumAsStringLiteralType;
 	/** sort types and vars in output */
 	private boolean sort;
 	

--- a/java2typescript-jackson/src/test/java/java2typescript/jackson/module/WriterPreferencesTest.java
+++ b/java2typescript-jackson/src/test/java/java2typescript/jackson/module/WriterPreferencesTest.java
@@ -28,6 +28,10 @@ public class WriterPreferencesTest {
 		VAL1, VAL2
 	}
 
+	static enum EnumOneValue {
+		VAL1
+	}
+
 	static class Dummy {
 		public String _String;
 	}
@@ -48,6 +52,24 @@ public class WriterPreferencesTest {
 		mWriter.preferences.useEnumPattern();
 
 		Module module = TestUtil.createTestModule(null, Enum.class);
+		Writer out = new StringWriter();
+
+		// Act
+		mWriter.write(module, out);
+		out.close();
+		System.out.println(out);
+
+		// Assert
+		ExpectedOutputChecker.checkOutputFromFile(out);
+	}
+
+	@Test
+	public void enumToStringLiteralType() throws IOException {
+		// Arrange
+		ExternalModuleFormatWriter mWriter = new ExternalModuleFormatWriter();
+		mWriter.preferences.useStringLiteralTypeForEnums();
+
+		Module module = TestUtil.createTestModule(null, Enum.class, EnumOneValue.class);
 		Writer out = new StringWriter();
 
 		// Act

--- a/java2typescript-jackson/src/test/resources/java2typescript/jackson/module/WriterPreferencesTest.enumToStringLiteralType.d.ts
+++ b/java2typescript-jackson/src/test/resources/java2typescript/jackson/module/WriterPreferencesTest.enumToStringLiteralType.d.ts
@@ -1,0 +1,6 @@
+export type Enum =
+    "VAL1"
+    | "VAL2";
+
+export type EnumOneValue =
+    "VAL1";


### PR DESCRIPTION

## Summary
- adds a new option to the WriterPreferences to change how enums are converted
- tests have been added
- changes are backwards-compatible
- default behavior not affected

## Details
The current options for enum conversion did not fit my use-case, so I implemented a new option which converts enums to [string literal types](https://www.typescriptlang.org/docs/handbook/advanced-types.html#string-literal-types). This is from my updates to the README: 

Another option available is to write enums as [String Literal Types](https://www.typescriptlang.org/docs/handbook/advanced-types.html#string-literal-types).
The advantage here is that the generated typescript definitions can be used with JSON that has the string value of the corresponding java enum value, while still maintaining
strong-typing. For example, take this java DTO class:

```java
class MyDto {
    static enum MyEnum {
        VAL1, VAl2, VAL3
    }
    public MyEnum myKey;
}

```

A java web server which is converting an instance of `MyDto` to JSON will likely return something like this:

```json
{
  "myKey": "VAL1"
}
```

The default for this tool is to create Typescript enums, which are integer-based. This will not work without some
conversion layer in your client code. To mitigate, you can use the `useStringLiteralTypeForEnums` option on the module
writer. This will generate a Typescript definition like this:

```TypeScript
export interface MyDto {
    myKey: MyEnum;
}
export type MyEnum = "VAL1" | "VAl2" | "VAL3";
```

This will keep strong-typing for the values, while allowing for string literal values of enum properties. Take a look at
the [test that turns on this preference](src/test/java/java2typescript/jackson/module/WriterPreferencesTest.java#L67)