### PR TITLE
fix(test): fix #65 test failures caused by "\n\r" vs "\n" line ending…

### DIFF
--- a/java2typescript-jackson/src/test/java/java2typescript/jackson/module/util/ExpectedOutputChecker.java
+++ b/java2typescript-jackson/src/test/java/java2typescript/jackson/module/util/ExpectedOutputChecker.java
@@ -31,6 +31,7 @@ public class ExpectedOutputChecker {
 	}
 
 	private static List<String> getLinesAlphabetically(String s) {
+		s = s.replace("\r", "");
 		List<String> lines = Lists.newArrayList(s.split("\\n"));
 		Collections.sort(lines);
 		return lines;


### PR DESCRIPTION
… diferences when comparing expected and actual output on windows