### PR TITLE
fix(enumPattern): fix #72 Java enum constant with name "name" (in low…

### DIFF
--- a/java2typescript-jackson/src/main/java/java2typescript/jackson/module/writer/EnumTypeToEnumPatternWriter.java
+++ b/java2typescript-jackson/src/main/java/java2typescript/jackson/module/writer/EnumTypeToEnumPatternWriter.java
@@ -32,11 +32,16 @@ public class EnumTypeToEnumPatternWriter implements CustomAbstractTypeWriter {
 			enumConstants = SortUtil.sort(enumConstants);
 		}
 		for (String value : enumConstants) {
-			writer.write(String.format(preferences.getIndentation() + "static %s = new %s('%s');\n", value, enumTypeName, value));
+			writer.write(String.format(preferences.getIndentation() + "static %s = new %s('%s');\n", getConstantName(value), enumTypeName, value));
 		}
 		writer.write(preferences.getIndentation() + "constructor(name:string){super(name);}\n");
 		preferences.decreaseIndention();
 		writer.write(preferences.getIndentation() + "}");
+	}
+
+	String getConstantName(String value) {
+		// lowercase "name" is special, can cause issues with JavaScript at runtime
+		return "name".equals(value) ? "name_" : value;
 	}
 
 }

--- a/java2typescript-jackson/src/main/java/java2typescript/jackson/module/writer/EnumTypeToStringLiteralTypeWriter.java
+++ b/java2typescript-jackson/src/main/java/java2typescript/jackson/module/writer/EnumTypeToStringLiteralTypeWriter.java
@@ -1,14 +1,14 @@
 package java2typescript.jackson.module.writer;
 
-import java2typescript.jackson.module.grammar.EnumType;
-import java2typescript.jackson.module.grammar.base.AbstractNamedType;
+import static java.lang.String.format;
 
 import java.io.IOException;
 import java.io.Writer;
 import java.util.Iterator;
 import java.util.List;
 
-import static java.lang.String.format;
+import java2typescript.jackson.module.grammar.EnumType;
+import java2typescript.jackson.module.grammar.base.AbstractNamedType;
 
 /**
  * Another alternate way of converting Java enums. This writer will convert enums to what is known as a String Literal
@@ -78,6 +78,8 @@ public class EnumTypeToStringLiteralTypeWriter implements CustomAbstractTypeWrit
 	}
 
 	String getConstantName(String value) {
+		// lowercase "name" is special, can cause issues with JavaScript at runtime
 		return "name".equals(value) ? "name_" : value;
 	}
+
 }

--- a/java2typescript-jackson/src/test/resources/java2typescript/jackson/module/WriterPreferencesTest.enumToEnumPattern.d.ts
+++ b/java2typescript-jackson/src/test/resources/java2typescript/jackson/module/WriterPreferencesTest.enumToEnumPattern.d.ts
@@ -7,7 +7,7 @@ export class EnumPatternBase {
 export class Enum extends EnumPatternBase {
     static VAL1 = new Enum('VAL1');
     static VAL2 = new Enum('VAL2');
-    static name = new Enum('name');
+    static name_ = new Enum('name');
     constructor(name:string){super(name);}
 }
 

--- a/java2typescript-jackson/src/test/resources/java2typescript/jackson/module/WriterPreferencesTest.indentWithTabs.d.ts
+++ b/java2typescript-jackson/src/test/resources/java2typescript/jackson/module/WriterPreferencesTest.indentWithTabs.d.ts
@@ -9,7 +9,7 @@ export module modName {
 	export class Enum extends EnumPatternBase {
 		static VAL1 = new Enum('VAL1');
 		static VAL2 = new Enum('VAL2');
-		static name = new Enum('name');
+		static name_ = new Enum('name');
 		constructor(name:string){super(name);}
 	}
 


### PR DESCRIPTION
…ercase) needs specail treatment, as compiled JS output "name" can't be used with EnumPattern (as javascript would otherwise throw Error)