### PR TITLE
option for adding constants when string literal enum option enabled

### DIFF
--- a/java2typescript-jackson/README.md
+++ b/java2typescript-jackson/README.md
@@ -68,8 +68,34 @@ export type MyEnum = "VAL1" | "VAl2" | "VAL3";
 ```
 
 This will keep strong-typing for the values, while allowing for string literal values of enum properties. Take a look at
-the [test that turns on this preference](src/test/java/java2typescript/jackson/module/WriterPreferencesTest.java#L67)
+the [test that turns on this preference](src/test/java/java2typescript/jackson/module/WriterPreferencesTest.java#L67).
 
+The `useStringLiteralTypeForEnums` method takes an optional boolean argument called `withConstants`. If this is set to `true`, two definitions will be generated from each java enum definition. So this:
+
+```Java
+class MyDto {
+    static enum MyEnum {
+        VAL1, VAl2, VAL3
+    }
+    public MyEnum myKey;
+}
+```
+
+Will generate this:
+
+```TypeScript
+export interface MyDto {
+    myKey: MyEnum;
+}
+export type MyEnum = "VAL1" | "VAl2" | "VAL3";
+export class MyEnumValues {
+    static VAL1: EnumOneValue = "VAL1";
+    static VAL2: EnumOneValue = "VAL2";
+    static VAL3: EnumOneValue = "VAL3";
+}
+```
+
+The reason for this feature is that prior to typescript v2.0.2, compile-time checks for string literal types were not exhaustive, resulting in certain situations where type-checking was unavailable (see discussion at [#68](https://github.com/raphaeljolivet/java2typescript/issues/68)). If you are using v2.0.2 or later, it is likely less helpful/necessary to enable this option.
 
 
 ### Mapping specific java classes to custom TypeScript types

--- a/java2typescript-jackson/src/main/java/java2typescript/jackson/module/writer/EnumTypeToStringLiteralTypeWriter.java
+++ b/java2typescript-jackson/src/main/java/java2typescript/jackson/module/writer/EnumTypeToStringLiteralTypeWriter.java
@@ -52,7 +52,9 @@ public class EnumTypeToStringLiteralTypeWriter implements CustomAbstractTypeWrit
 		}
 		preferences.decreaseIndention();
 
-		writeConstants(writer, preferences, enumTypeName, enumConstants);
+		if (preferences.isConstantsForStringLiteralTypeEnums()) {
+			writeConstants(writer, preferences, enumTypeName, enumConstants);
+		}
 	}
 
 	private void writeConstants(

--- a/java2typescript-jackson/src/main/java/java2typescript/jackson/module/writer/WriterPreferences.java
+++ b/java2typescript-jackson/src/main/java/java2typescript/jackson/module/writer/WriterPreferences.java
@@ -13,19 +13,28 @@ public class WriterPreferences {
 
 	private List<CustomAbstractTypeWriter> customWriters = new ArrayList<CustomAbstractTypeWriter>();
 	private boolean useEnumPattern;
+	private boolean enumAsStringLiteralType = false;
+	private boolean constantsForStringLiteralTypeEnums = false;
+	/** sort types and vars in output */
+	private boolean sort;
 
 	public boolean isStringLiteralTypeForEnums() {
 		return enumAsStringLiteralType;
 	}
 
-	public void useStringLiteralTypeForEnums() {
-        addWriter(new EnumTypeToStringLiteralTypeWriter());
+	public void useStringLiteralTypeForEnums(boolean withConstants) {
+		addWriter(new EnumTypeToStringLiteralTypeWriter());
 		this.enumAsStringLiteralType = true;
+		this.constantsForStringLiteralTypeEnums = withConstants;
 	}
 
-	private boolean enumAsStringLiteralType;
-	/** sort types and vars in output */
-	private boolean sort;
+	public void useStringLiteralTypeForEnums() {
+		useStringLiteralTypeForEnums(false);
+	}
+
+	public boolean isConstantsForStringLiteralTypeEnums() {
+		return this.constantsForStringLiteralTypeEnums;
+	}
 	
 	public void useEnumPattern() {
 		addWriter(new EnumTypeToEnumPatternWriter());

--- a/java2typescript-jackson/src/test/java/java2typescript/jackson/module/WriterPreferencesTest.java
+++ b/java2typescript-jackson/src/test/java/java2typescript/jackson/module/WriterPreferencesTest.java
@@ -84,6 +84,24 @@ public class WriterPreferencesTest {
 	}
 
 	@Test
+	public void enumToStringLiteralTypeWithConstants() throws IOException {
+		// Arrange
+		ExternalModuleFormatWriter mWriter = new ExternalModuleFormatWriter();
+		mWriter.preferences.useStringLiteralTypeForEnums(true);
+
+		Module module = TestUtil.createTestModule(null, Enum.class, EnumOneValue.class);
+		Writer out = new StringWriter();
+
+		// Act
+		mWriter.write(module, out);
+		out.close();
+		System.out.println(out);
+
+		// Assert
+		ExpectedOutputChecker.checkOutputFromFile(out);
+	}
+
+	@Test
 	public void enumPatternBaseNotAddedWhenNotNeeded() throws IOException {
 		// Arrange
 		ExternalModuleFormatWriter mWriter = new ExternalModuleFormatWriter();

--- a/java2typescript-jackson/src/test/resources/java2typescript/jackson/module/WriterPreferencesTest.enumToStringLiteralType.d.ts
+++ b/java2typescript-jackson/src/test/resources/java2typescript/jackson/module/WriterPreferencesTest.enumToStringLiteralType.d.ts
@@ -3,15 +3,5 @@ export type Enum =
     | "VAL2"
     | "name";
 
-export class EnumValues {
-    static VAL1: Enum = "VAL1";
-    static VAL2: Enum = "VAL2";
-    static name_: Enum = "name";
-}
-
 export type EnumOneValue =
     "VAL1";
-
-export class EnumOneValueValues {
-    static VAL1: EnumOneValue = "VAL1";
-}

--- a/java2typescript-jackson/src/test/resources/java2typescript/jackson/module/WriterPreferencesTest.enumToStringLiteralTypeWithConstants.d.ts
+++ b/java2typescript-jackson/src/test/resources/java2typescript/jackson/module/WriterPreferencesTest.enumToStringLiteralTypeWithConstants.d.ts
@@ -1,0 +1,17 @@
+export type Enum =
+    "VAL1"
+    | "VAL2"
+    | "name";
+
+export class EnumValues {
+    static VAL1: Enum = "VAL1";
+    static VAL2: Enum = "VAL2";
+    static name_: Enum = "name";
+}
+
+export type EnumOneValue =
+    "VAL1";
+
+export class EnumOneValueValues {
+    static VAL1: EnumOneValue = "VAL1";
+}


### PR DESCRIPTION
As per #68, I have made the constant generation for enums opt-in.

```java
mWriter.preferences.useEnumPattern();
mWriter.preferences.createConstantsForStringLiteralTypeEnums();
```