### PR TITLE
added support for declared module format

### DIFF
--- a/java2typescript-jackson/README.md
+++ b/java2typescript-jackson/README.md
@@ -7,6 +7,9 @@ Java classes are converted to TypeScript interfaces.
 ### Module (generated output) format
 TypeScript has a concept of [internal](http://www.typescriptlang.org/Handbook#modules) and [external](http://www.typescriptlang.org/Handbook#modules-going-external) modules, that have slightly different formats (see the test output for [internal](src/test/resources/java2typescript/jackson/module/DefinitionGeneratorTest.internalModuleFormat.d.ts) vs [external](src/test/resources/java2typescript/jackson/module/DefinitionGeneratorTest.externalModuleFormat.d.ts) module format). By default, internal module format is used (that adds one line before and after content of external module format). To write in the external module format, use the `ExternalModuleFormatWriter` class (see [the test for an example](src/test/java/java2typescript/jackson/module/DefinitionGeneratorTest.java#L85-L97)).
 
+A third option is to use the `AmbientdModuleFormatWriter`, which behaves much like the `InternalModuleFormatWriter`, except it uses `declare module ...` on the outer wrapping module instead of `export module ...`. This is called an "ambient" module in TypeScript lingo. For more information, see the [typescript docs on modules](https://www.typescriptlang.org/docs/handbook/modules.html).
+
+>NOTE: A note about terminology: It's important to note that in TypeScript 1.5, the nomenclature has changed. "Internal modules" are now "namespaces". "External modules" are now simply "modules", as to align with ECMAScript 2015's terminology, (namely that module X { is equivalent to the now-preferred namespace X {).
 
 ### Ignored methods
 When generating TypeScript from Java classes <sup>(actually when Java classes are analysed)</sup>, some methods are excluded:

--- a/java2typescript-jackson/src/main/java/java2typescript/jackson/module/writer/AmbientModuleFormatWriter.java
+++ b/java2typescript-jackson/src/main/java/java2typescript/jackson/module/writer/AmbientModuleFormatWriter.java
@@ -1,0 +1,25 @@
+package java2typescript.jackson.module.writer;
+
+import static java.lang.String.format;
+
+import java.io.IOException;
+import java.io.Writer;
+
+import java2typescript.jackson.module.grammar.Module;
+
+/**
+ * Generates TypeScript type definitions for given module in declared module format
+ */
+public class AmbientModuleFormatWriter extends ExternalModuleFormatWriter {
+
+  @Override
+  public void write(Module module, Writer writer) throws IOException {
+    writer.write(format("declare module %s {\n\n", module.getName()));
+    preferences.increaseIndentation();
+    writeModuleContent(module, writer);
+    preferences.decreaseIndention();
+    writer.write("}\n");
+    writer.flush();
+  }
+
+}

--- a/java2typescript-jackson/src/test/java/java2typescript/jackson/module/DefinitionGeneratorTest.java
+++ b/java2typescript-jackson/src/test/java/java2typescript/jackson/module/DefinitionGeneratorTest.java
@@ -22,6 +22,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Map;
 
+import java2typescript.jackson.module.writer.AmbientModuleFormatWriter;
 import org.junit.Test;
 
 import com.fasterxml.jackson.annotation.JsonTypeName;
@@ -113,6 +114,21 @@ public class DefinitionGeneratorTest {
 
 		// Act
 		new ExternalModuleFormatWriter().write(module, out);
+		out.close();
+		System.out.println(out);
+
+		// Assert
+		ExpectedOutputChecker.checkOutputFromFile(out);
+	}
+
+	@Test
+	public void ambientModuleFormat() throws IOException {
+		// Arrange
+		Module module = createTestModule();
+		Writer out = new StringWriter();
+
+		// Act
+		new AmbientModuleFormatWriter().write(module, out);
 		out.close();
 		System.out.println(out);
 

--- a/java2typescript-jackson/src/test/resources/java2typescript/jackson/module/DefinitionGeneratorTest.ambientModuleFormat.d.ts
+++ b/java2typescript-jackson/src/test/resources/java2typescript/jackson/module/DefinitionGeneratorTest.ambientModuleFormat.d.ts
@@ -1,0 +1,29 @@
+declare module modName {
+
+    export interface StringClass {
+        someField: string;
+    }
+
+    export enum ChangedEnumName {
+        VAL1,
+        VAL2,
+        VAL3,
+    }
+
+    export interface TestClass {
+        _String: string;
+        _boolean: boolean;
+        _Boolean: boolean;
+        _int: number;
+        _float: number;
+        stringArray: string[];
+        map: { [key: string ]: boolean;};
+        recursive: TestClass;
+        recursiveArray: TestClass[];
+        stringArrayList: string[];
+        booleanCollection: boolean[];
+        _enum: ChangedEnumName;
+        aMethod(param0: boolean, param1: string): string;
+    }
+
+}


### PR DESCRIPTION
This PR allows for generated typescript with a `declare`d wrapper module. This is a common pattern for describing third-party library types. Some relevant resources: 

- [TS Modules](https://www.typescriptlang.org/docs/handbook/modules.html)
- [Explanation of `declare` on StackOverflow](http://stackoverflow.com/questions/14345485/whats-the-difference-between-declare-class-and-interface-in-typescript)