### PR TITLE
Use 'key in type' syntax for enum keys in maps

### DIFF
--- a/java2typescript-jackson/src/main/java/java2typescript/jackson/module/grammar/MapType.java
+++ b/java2typescript-jackson/src/main/java/java2typescript/jackson/module/grammar/MapType.java
@@ -29,9 +29,17 @@ public class MapType extends AbstractType {
 
 	@Override
 	public void write(Writer writer) throws IOException {
-		writer.write("{ [key: ");
-		keyType.write(writer);
-		writer.write(" ]: ");
+		// TODO: only use this "key in <ENUM>" syntax when useStringLiteralTypeForEnums is enabled.
+		if (keyType instanceof EnumType) {
+			writer.write("{ [key in ");
+			keyType.write(writer);
+			writer.write(" ] ? : ");
+		} else {
+			writer.write("{ [key: ");
+			keyType.write(writer);
+			writer.write(" ]: ");
+		}
+
 		valueType.write(writer);
 		writer.write(";}");
 	}

--- a/java2typescript-jackson/src/test/java/java2typescript/jackson/module/WriterPreferencesTest.java
+++ b/java2typescript-jackson/src/test/java/java2typescript/jackson/module/WriterPreferencesTest.java
@@ -5,6 +5,7 @@ import java.io.StringWriter;
 import java.io.Writer;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 import org.junit.Test;
 
@@ -43,6 +44,10 @@ public class WriterPreferencesTest {
 		public static final String MY_CONSTANT_STRING = "stringValue";
 		public static final boolean MY_CONSTANT_BOOLEAN = true;
 	}
+
+	static class TestClassHasMapWithEnumKey {
+		public Map<Enum, String> enumKeyMap;
+	}
 	
 	enum E{B,C,A}
 
@@ -71,7 +76,7 @@ public class WriterPreferencesTest {
 		ExternalModuleFormatWriter mWriter = new ExternalModuleFormatWriter();
 		mWriter.preferences.useStringLiteralTypeForEnums();
 
-		Module module = TestUtil.createTestModule(null, Enum.class, EnumOneValue.class);
+		Module module = TestUtil.createTestModule(null, Enum.class, EnumOneValue.class, TestClassHasMapWithEnumKey.class);
 		Writer out = new StringWriter();
 
 		// Act

--- a/java2typescript-jackson/src/test/resources/java2typescript/jackson/module/WriterPreferencesTest.enumToStringLiteralType.d.ts
+++ b/java2typescript-jackson/src/test/resources/java2typescript/jackson/module/WriterPreferencesTest.enumToStringLiteralType.d.ts
@@ -3,5 +3,9 @@ export type Enum =
     | "VAL2"
     | "name";
 
+export interface TestClassHasMapWithEnumKey {
+    enumKeyMap: { [key in Enum ] ? : string;};
+}
+
 export type EnumOneValue =
     "VAL1";


### PR DESCRIPTION
Currently, a `Map<K,V>` type where `K` is not a string or number type, java2typescript outputs invalid ts. Example:

```java
class Foo {
  static enum MyEnum { A, B, C }
  public Map<MyEnum, String> map;
}
```

results in:

```typescript
// if using string literal types:
type MyEnum = 'A' | 'B' | 'C';
// otherwise:
enum MyEnum { A, B, C }

interface Foo {
  // Should be `key in MyEnum`
  map: {[key: MyEnum]: string}
}
```

I wanted to make this change specific to when you elect to convert enums to string literal types only, but I could not achieve this (the `accepts` method never gets called for `MapType`s).

@atsu85  or @raphaeljolivet, if you know of a way this can be achieved better, please let me know!
